### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ Feedstock Maintainers
 =====================
 
 * [@alisterburt](https://github.com/alisterburt/)
-* [@goanpeca](https://github.com/goanpeca/)
 * [@jaimergp](https://github.com/jaimergp/)
 * [@jni](https://github.com/jni/)
 * [@sofroniewn](https://github.com/sofroniewn/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,6 @@ about:
 extra:
   recipe-maintainers:
     - alisterburt
-    - goanpeca
     - jaimergp
     - jni
     - sofroniewn


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #13